### PR TITLE
Use OTOML instead of To.ml for TOML parsing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,6 @@
 name: install-test
 
-on:
-  push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.4.0 (Unreleased)
+
+- Switch from To.ml to OTOML library (#1).
+
 ## 0.3.0 (July 28, 2020)
 
 - Validate colors from TextMate themes.

--- a/camyll.opam
+++ b/camyll.opam
@@ -32,7 +32,7 @@ depends: [
   "plist-xml" {< "0.4"}
   "re" {>= "1.9" & < "2.0"}
   "textmate-language" {>= "0.3.1" & < "0.4"}
-  "toml" {>= "7" & < "8"}
+  "otoml" {>= "0.9.2"}
   "uri" {>= "4.2" & < "5"}
   "odoc" {with-doc}
 ]

--- a/camyll.opam
+++ b/camyll.opam
@@ -32,7 +32,7 @@ depends: [
   "plist-xml" {< "0.4"}
   "re" {>= "1.9" & < "2.0"}
   "textmate-language" {>= "0.3.1" & < "0.4"}
-  "otoml" {>= "0.9.2"}
+  "otoml" {>= "0.9.3"}
   "uri" {>= "4.2" & < "5"}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -35,5 +35,5 @@ Features:
   (plist-xml (< 0.4))
   (re (and (>= 1.9) (< 2.0)))
   (textmate-language (and (>= 0.3.1) (< 0.4)))
-  (otoml (>= 0.9.2))
+  (otoml (>= 0.9.3))
   (uri (and (>= 4.2) (< 5)))))

--- a/dune-project
+++ b/dune-project
@@ -35,5 +35,5 @@ Features:
   (plist-xml (< 0.4))
   (re (and (>= 1.9) (< 2.0)))
   (textmate-language (and (>= 0.3.1) (< 0.4)))
-  (toml (and (>= 7) (< 8)))
+  (otoml (>= 0.9.2))
   (uri (and (>= 4.2) (< 5)))))

--- a/src/build.ml
+++ b/src/build.ml
@@ -73,20 +73,15 @@ let add_taxonomy t taxonomy name data =
     | Some items -> Hashtbl.replace taxonomy.items name (data :: items)
 
 let add_taxonomies t url page =
-  let get_string_array v =
-    try Some (Otoml.get_array Otoml.get_string v)
-    with _ -> None
-  in
   match Otoml.find_opt page.frontmatter Otoml.get_table ["taxonomies"] with
   | None -> ()
   | Some taxonomies ->
     taxonomies |> List.iter begin fun (taxonomy, v) ->
-      match get_string_array v with
-      | None -> failwith "Expected an array of strings"
-      | Some tags ->
+      match Otoml.get_array Otoml.get_string v with
+      | exception Otoml.Type_error _ -> failwith "Expected an array of strings"
+      | tags ->
         tags |> List.iter begin fun tag ->
-          let jingoo = jingoo_of_page url page in
-          add_taxonomy t taxonomy tag jingoo
+          add_taxonomy t taxonomy tag (jingoo_of_page url page)
         end
     end
 

--- a/src/config.ml
+++ b/src/config.ml
@@ -59,7 +59,7 @@ let of_toml toml =
 let with_config f =
   let config =
     match Otoml.Parser.from_file_result "config.toml" with
-    | Error(e) -> failwith e
+    | Error e -> failwith e
     | Ok toml ->
       match of_toml toml with
       | Some config -> config

--- a/src/config.ml
+++ b/src/config.ml
@@ -1,3 +1,5 @@
+module Otoml = Otoml_impl.T
+
 type taxonomy = {
   name : string;
   layout : string;
@@ -37,17 +39,17 @@ let rec mapM f = function
       | Some xs -> Some (y :: xs)
 
 let taxonomy_of_toml toml =
-  let open Toml.Lenses in
-  let+ name = get toml (key "name" |-- string)
-  and+ layout = get toml (key "layout" |-- string) in
+  let+ name = Otoml.find_opt toml Otoml.get_string ["name"]
+  and+ layout = Otoml.find_opt toml Otoml.get_string ["layout"] in
   { name; layout }
 
 let of_toml toml =
-  let open Toml.Lenses in
-  let* dest_dir = get toml (key "dest_dir" |-- string)
-  and* agda_dir = get toml (key "agda_dir" |-- string)
-  and* exclude = get toml (key "exclude" |-- array |-- strings)
-  and* taxonomies = get toml (key "taxonomies" |-- array |-- tables) in
+  let* dest_dir = Otoml.find_opt toml Otoml.get_string ["dest_dir"]
+  and* agda_dir = Otoml.find_opt toml Otoml.get_string ["agda_dir"]
+  and* exclude = Otoml.find_opt toml (Otoml.get_array Otoml.get_string) ["exclude"]
+  and* taxonomies =
+    Otoml.find_opt toml (Otoml.get_array Otoml.get_value) ["taxonomies"]
+  in
   let+ taxonomies = mapM taxonomy_of_toml taxonomies in
   { dest_dir
   ; agda_dir
@@ -56,9 +58,9 @@ let of_toml toml =
 
 let with_config f =
   let config =
-    match Toml.Parser.from_filename "config.toml" with
-    | `Error(e, _) -> failwith e
-    | `Ok toml ->
+    match Otoml.Parser.from_file_result "config.toml" with
+    | Error(e) -> failwith e
+    | Ok toml ->
       match of_toml toml with
       | Some config -> config
       | None -> failwith "Could not read config.toml"

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,4 @@
  (name camyll)
  (libraries
   calendar httpaf httpaf-lwt-unix jingoo lambdasoup lwt omd plist-xml re
-  textmate-language toml uri))
+  textmate-language uri otoml ISO8601))

--- a/src/otoml_impl.ml
+++ b/src/otoml_impl.ml
@@ -1,0 +1,19 @@
+module ISODate = struct
+  type t = float
+
+  let parse date = fst (ISO8601.Permissive.datetime_tz ~reqtime:false date)
+
+  let local_time_of_string = parse
+  let local_date_of_string = parse
+  let local_datetime_of_string = parse
+  let offset_datetime_of_string = parse
+
+  let local_time_to_string = ISO8601.Permissive.string_of_time
+  let local_date_to_string = ISO8601.Permissive.string_of_date
+  let local_datetime_to_string = ISO8601.Permissive.string_of_datetime
+  let offset_datetime_to_string = ISO8601.Permissive.string_of_datetime
+end
+
+module T = Otoml.Base.Make (Otoml.Base.OCamlInteger) (Otoml.Base.OCamlFloat) (ISODate)
+
+

--- a/src/otoml_impl.ml
+++ b/src/otoml_impl.ml
@@ -14,6 +14,6 @@ module ISODate = struct
   let offset_datetime_to_string = ISO8601.Permissive.string_of_datetime
 end
 
-module T = Otoml.Base.Make (Otoml.Base.OCamlInteger) (Otoml.Base.OCamlFloat) (ISODate)
+module T = Otoml.Base.Make (Otoml.Base.OCamlNumber) (ISODate)
 
 


### PR DESCRIPTION
[OTOML](https://opam.ocaml.org/packages/otoml/) is a TOML parsing/printing/manipulation library I made to alleviate the design shortcomings of To.ml. It's fully 1.0.0-compliant, offers a much easier way to retrieve nested values, and allows you to bring your own datetime parsing dependency.

One immediate improvement is informative parse errors:

```
$ cat config.toml
source_dir = "site"
dest_dir = "public"
agda_dir = "lagda"
exclude = ["*.agdai" # missing closing bracket
...

$ ../_build/default/bin/main.exe build
camyll: Syntax error on line 6, character 1: Malformed array (missing closing square bracket?)
```
Datetime, big int and big float libraries are plugged into OTML using a functor. The default implementation exposes datetime values as strings for the user to parse.

To ensure perfect compatibility and to make minimal changes to your original code, this patch builds an OTOML implementation with exactly the same parsing function that you contributed to To.ml back then, `ISO8601.Permissive.datetime_tz ~reqtime:false` (see `src/otoml_impl.ml`).

However, since datetime parsing is no longer a black box, you can later replace it with another library to add support for more formats, e.g. oDate.

OTOML can also distinguish between "key doesn't exist" and "value has wrong type" situations, so it will also be possible to provide better error reporting. I haven't done it so as to keep the change as small as possible, but it can be done.

I verified that the example site builds fine with my changes. Let me know if you have any questions or suggestions.